### PR TITLE
Tell users to use a droplet ID for host argument

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -87,7 +87,7 @@ optional arguments:
   --list                List all active Droplets as Ansible inventory
                         (default: True)
   --host HOST           Get all Ansible inventory variables about a specific
-                        Droplet
+                        Droplet by Droplet ID
   --all                 List all DigitalOcean information as JSON
   --droplets, -d        List Droplets as JSON
   --regions             List Regions as JSON
@@ -342,7 +342,7 @@ class DigitalOceanInventory(object):
         parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based on DigitalOcean credentials')
 
         parser.add_argument('--list', action='store_true', help='List all active Droplets as Ansible inventory (default: True)')
-        parser.add_argument('--host', action='store', help='Get all Ansible inventory variables about a specific Droplet')
+        parser.add_argument('--host', action='store', help='Get all Ansible inventory variables about a specific Droplet by Droplet ID')
 
         parser.add_argument('--all', action='store_true', help='List all DigitalOcean information as JSON')
         parser.add_argument('--droplets', '-d', action='store_true', help='List Droplets as JSON')
@@ -467,7 +467,11 @@ class DigitalOceanInventory(object):
 
     def load_droplet_variables_for_host(self):
         """ Generate a JSON response to a --host call """
-        host = int(self.args.host)
+        try:
+            host = int(self.args.host)
+        except ValueError:
+            sys.exit("Invalid host argument, value must be a numeric Droplet ID")
+
         droplet = self.manager.show_droplet(host)
         info = self.do_namespace(droplet)
         return {'droplet': info}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Include a catch for ValueError when uses attempt to pass a non-numeric value to `--host`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib/inventory/digital_ocean
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.5devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
