### PR TITLE
aws: Add missing parameters in lambda_info

### DIFF
--- a/changelogs/fragments/lambda_info_max_item.yml
+++ b/changelogs/fragments/lambda_info_max_item.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add missing max_items and next_marker parameters in lambda_info module which was missing since inception (https://github.com/ansible/ansible/issues/63489).

--- a/lib/ansible/modules/cloud/amazon/lambda_info.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_info.py
@@ -44,6 +44,12 @@ options:
   event_source_arn:
     description:
       - For query type 'mappings', this is the Amazon Resource Name (ARN) of the Amazon Kinesis or DynamoDB stream.
+  max_items:
+    description:
+      - Maximum number of items to return for various get/list requests.
+  next_marker:
+    description:
+      - Specifies the NextMarker entry from the first response to get the next page of results.
 author: Pierre Jodouin (@pjodouin)
 requirements:
     - boto3
@@ -341,7 +347,9 @@ def main():
     argument_spec = dict(
         function_name=dict(required=False, default=None, aliases=['function', 'name']),
         query=dict(required=False, choices=['aliases', 'all', 'config', 'mappings', 'policy', 'versions'], default='all'),
-        event_source_arn=dict(required=False, default=None)
+        event_source_arn=dict(required=False, default=None),
+        max_items=dict(),
+        next_marker=dict(),
     )
 
     module = AnsibleAWSModule(


### PR DESCRIPTION
##### SUMMARY

max_items and next_marker parameters are added in lambda_info module.
These values were missing since the inception of module.

Fixes: #63489

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/lambda_info_max_item.yml
lib/ansible/modules/cloud/amazon/lambda_info.py
