### PR TITLE
create deb file dynamically instead

### DIFF
--- a/changelogs/fragments/apt_recommends.yml
+++ b/changelogs/fragments/apt_recommends.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - apt - install recommended packages when installing package via deb file (https://github.com/ansible/ansible/issues/29726).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -886,6 +886,11 @@ def install_deb(
         except Exception as e:
             m.fail_json(msg="Unable to install package: %s" % to_native(e))
 
+        # Install 'Recommends' of this deb file
+        if install_recommends:
+            pkg_recommends = get_field_of_deb(m, deb_file, "Recommends")
+            deps_to_install.extend([pkg_name.strip() for pkg_name in pkg_recommends.split()])
+
         # and add this deb to the list of packages to install
         pkgs_to_install.append(deb_file)
 

--- a/test/integration/targets/apt/tasks/url-with-deps.yml
+++ b/test/integration/targets/apt/tasks/url-with-deps.yml
@@ -48,9 +48,37 @@
         - dpkg_result is successful
         - dpkg_result.rc == 0
 
-  always:
-    - name: uninstall echo-hello with apt
+    - name: Install deb file with recommends from URL
       apt:
-        pkg: echo-hello
+        deb: https://github.com/Akasurde/git_demo/raw/master/bar.deb
+        install_recommends: yes
+      register: apt_url_deps
+
+    - name: check to make sure we installed the package
+      shell: dpkg -l | grep bar
+      failed_when: False
+      register: bar_dpkg_result
+
+    - name: check to make sure we installed the package's recommends
+      shell: dpkg -l | grep rolldice
+      failed_when: False
+      register: vim_tiny_dpkg_result
+
+    - name: verify real installation of bar
+      assert:
+        that:
+        - apt_url_deps is changed
+        - bar_dpkg_result is successful
+        - bar_dpkg_result.rc == 0
+        - vim_tiny_dpkg_result is successful
+        - vim_tiny_dpkg_result.rc == 0
+
+  always:
+    - name: uninstall packages with apt
+      apt:
+        pkg:
+          - echo-hello
+          - rolldice
+          - bar
         state: absent
         purge: yes

--- a/test/integration/targets/apt/tasks/url-with-deps.yml
+++ b/test/integration/targets/apt/tasks/url-with-deps.yml
@@ -50,17 +50,17 @@
 
     - name: Install deb file with recommends from URL
       apt:
-        deb: https://github.com/Akasurde/git_demo/raw/master/bar.deb
+        deb: "{{ repodir }}/dists/stable/main/binary-all/bar_0.0.1_amd64.deb"
         install_recommends: yes
       register: apt_url_deps
 
     - name: check to make sure we installed the package
-      shell: dpkg -l | grep bar
+      shell: dpkg -l bar
       failed_when: False
       register: bar_dpkg_result
 
     - name: check to make sure we installed the package's recommends
-      shell: dpkg -l | grep rolldice
+      shell: dpkg -l rolldice
       failed_when: False
       register: vim_tiny_dpkg_result
 

--- a/test/integration/targets/setup_deb_repo/files/package_specs/stable/bar
+++ b/test/integration/targets/setup_deb_repo/files/package_specs/stable/bar
@@ -1,0 +1,10 @@
+Section: devel
+Priority: optional
+Standards-Version: 2.3.3
+Package: bar
+Version: 0.0.1
+Architecture: amd64
+Maintainer: Ansible Maintainers <maintainers@example.com>
+Recommends: rolldice
+Description: example package to test in Ansible apt module
+Homepage: https://www.ansible.com/


### PR DESCRIPTION
##### SUMMARY

Thinking some more about this, it seems like we could create the deb file in the test.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
